### PR TITLE
fix: report should be created in data dir

### DIFF
--- a/mcp/api/json_storage.py
+++ b/mcp/api/json_storage.py
@@ -23,10 +23,10 @@ import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-# Resolve data directory relative to the MCP server root
-_API_DIR = Path(__file__).resolve().parent          # .../server/api
-_SERVER_DIR = _API_DIR.parent                        # .../server
-DATA_DIR = _SERVER_DIR / "data"
+# Resolve data directory — use opencode's standard data dir so it lands in the
+# volume-mounted path (e.g. ./darkmoon-settings or ./reports on the host).
+_OPENDATA_DIR = Path.home() / ".local" / "share" / "opencode"
+DATA_DIR = _OPENDATA_DIR
 
 PROJECTS_FILE = DATA_DIR / "projects.json"
 TARGETS_FILE = DATA_DIR / "targets.json"


### PR DESCRIPTION
# Issue

In standard usage conditions the tool often outputs a line after a scan has finish about some report being written to the disk : `Report saved to: `/reports/pentest_report_machine.fqdn.tld_20260623-0737.md`. But if we look at the `./reports` subfolder, it's empty.

# Cause
The docker-compose.yml file mounts the host reports folder like this : `./reports:/root/.local/share/opencode/reports/:rw`.
But actually reports arebeing written to /opt/darkmoon/mcp/server/src/data/reports/.

# Fix
Update json_storage.py toesolve the data directory to opencode's standard data dir, which is mounted to the hosts' `reports` subfolder