### PR TITLE
Use the configured on-prem model as the default in opencode

### DIFF
--- a/conf/apply-settings.sh
+++ b/conf/apply-settings.sh
@@ -79,8 +79,13 @@ mkdir -p "$OPENCODE_CONFIG_DIR" "$OPENCODE_AUTH_DIR"
 # Write opencode.json (ALWAYS)
 #######################################
 
-# Build optional provider block for local mode
-LOCAL_PROVIDER_BLOCK=""
+# Build optional provider block.
+# - local mode  : declares a full OpenAI-compatible provider.
+# - anthropic   : registers the custom model id under the built-in "anthropic"
+#                 provider, otherwise opencode validates the configured model
+#                 against its hard-coded catalogue and rejects it with
+#                 ProviderModelNotFoundError.
+PROVIDER_BLOCK=""
 if [ "$USE_LOCAL" = true ]; then
   # Optional API key for authenticated OpenAI-compatible endpoints (Bearer auth).
   # JSON-escaped via python3 so keys containing quotes/backslashes can't break the config.
@@ -88,7 +93,7 @@ if [ "$USE_LOCAL" = true ]; then
   if [ -n "${OPENCODE_LOCAL_API_KEY:-}" ]; then
     LOCAL_API_KEY_OPTION=$(OPENCODE_LOCAL_API_KEY="$OPENCODE_LOCAL_API_KEY" python3 -c 'import json,os; print(",\n        \"apiKey\": " + json.dumps(os.environ["OPENCODE_LOCAL_API_KEY"]))')
   fi
-  LOCAL_PROVIDER_BLOCK=$(cat <<PROVEOF
+  PROVIDER_BLOCK=$(cat <<PROVEOF
 ,
 
   "provider": {
@@ -107,11 +112,29 @@ if [ "$USE_LOCAL" = true ]; then
   }
 PROVEOF
 )
+elif [ "$USE_ANTHROPIC" = true ]; then
+  PROVIDER_BLOCK=$(cat <<PROVEOF
+,
+
+  "provider": {
+    "anthropic": {
+      "models": {
+        "${ANTHROPIC_MODEL}": {
+          "name": "${ANTHROPIC_MODEL}"
+        }
+      }
+    }
+  }
+PROVEOF
+)
 fi
 
 cat > "$OPENCODE_CONFIG_FILE" <<EOF
 {
-  "\$schema": "https://opencode.ai/config.json"${LOCAL_PROVIDER_BLOCK},
+  "\$schema": "https://opencode.ai/config.json"${PROVIDER_BLOCK},
+
+  "model": "$FINAL_MODEL",
+  "small_model": "$FINAL_MODEL",
 
   "mcp": {
     "darkmoon": {


### PR DESCRIPTION
## Problem

When using an on-prem Anthropic-compatible endpoint (ANTHROPIC_BASE_URL / ANTHROPIC_MODEL / ANTHROPIC_API_KEY), the configured model was ignored. Runs went out as claude-sonnet-4-6 and title generation failed on claude-haiku-4-5 instead of using the configured model.

<img width="600" height="233" alt="image" src="https://github.com/user-attachments/assets/41bbe019-56a5-49a4-a8eb-40958c3ff068" />

<img width="477" height="132" alt="image" src="https://github.com/user-attachments/assets/85ce602d-59c8-4ec7-8019-db714388b6f5" />


## Cause

`apply-settings.sh` only set the model per agent. But:

- `opencode run` runs the built-in `build` agent by default, not the `pentest` agent, so it used the anthropic provider's hard-coded default model instead of the configured one.
- The "small model" used for session titles also defaulted to a Claude model that the on-prem endpoint does not serve.
- Setting the model at the root level only is not enough either: opencode validates the model against the anthropic provider's built-in catalogue and rejects unknown ids with ProviderModelNotFoundError.

## Fix

In the generated opencode.json:

- Add root-level `model` and `small_model` set to the configured model, so the default agent and title generation both use it.
- Register the custom model id under the `anthropic` provider so opencode accepts it instead of rejecting it as unknown.

## AI

This PR was AI assisted